### PR TITLE
fix: Configure Biome explicitly for JSON in VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+	"editor.defaultFormatter": "biomejs.biome",
+	"biome.requireConfigFile": true,
+	"editor.formatOnSave": true,
+	"[json]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[jsonc]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	}
+}


### PR DESCRIPTION
This PR updates the VSCode workspace settings to explicitly set Biome as the formatter for JSON and JSONC files and enables format on save.