### PR TITLE
feat: Refactor start_process monitoring hint

### DIFF
--- a/.cursor/plans/tail.md
+++ b/.cursor/plans/tail.md
@@ -1,0 +1,133 @@
+Okay, let's refactor the success response message for the `start_process` tool to align with the desired instructional phrasing for tailing logs.
+
+The goal is to change the `monitoring_hint` field in the success payload to sound like an instruction to run the `tail` command *if* the user implicitly asked for it, rather than just suggesting it as an option.
+
+---
+
+**Step-by-Step Guide:**
+
+**1. Locate the Success Payload Construction:**
+
+*   Open the file `src/processLogic.ts`.
+*   Navigate to the end of the `_startProcess` function.
+*   Find the section where the `successPayload` object is created, just before the `return ok(...)` call.
+
+**2. Modify the `monitoring_hint` Generation:**
+
+*   Identify the existing line(s) that define the `monitoringHint` string.
+*   Replace that logic with the following code, which conditionally formats the hint based on whether a `logFilePath` (and therefore a `tail_command`) exists:
+
+    ```typescript
+    // src/processLogic.ts - Inside _startProcess, near the end before return ok(...)
+
+    // ... (previous code determining finalStatus, message, logsToReturn) ...
+
+    // Generate the tail command first
+    const tailCommand = logFilePath ? `tail -f "${logFilePath}"` : null;
+
+    // Conditionally generate the monitoring hint based on tail command availability
+    let monitoringHint: string;
+    if (tailCommand) {
+      // Phrasing for when file logging (and thus tailing) is possible
+      monitoringHint = `If you requested to tail the '${label}' process, please run this command in a separate background terminal: ${tailCommand}. For status updates or recent inline logs, use check_process_status('${label}').`;
+    } else {
+      // Phrasing for when file logging is disabled
+      monitoringHint = `For status updates or recent inline logs, use check_process_status('${label}'). File logging is not enabled for this process.`;
+    }
+
+    // Keep the detailed startup/settling message separate if needed
+    const infoMessage = message; // 'message' contains the details about settling/timeout
+
+    // Construct the final payload
+    const successPayload: z.infer<typeof StartSuccessPayloadSchema> = {
+      label,
+      // Keep the primary message concise about the start status
+      message: `Process "${label}" started with status: ${finalStatus}.`,
+      status: finalStatus,
+      pid: currentInfoAfterWait.pid,
+      command: command,
+      args: args,
+      cwd: effectiveWorkingDirectory,
+      // Ensure logsToReturn uses the full length from the earlier modification
+      logs: formatLogsForResponse(
+        currentInfoAfterWait.logs.map((l: LogEntry) => l.content),
+        currentInfoAfterWait.logs.length, // Use the full length here
+      ),
+      monitoring_hint: monitoringHint, // Use the newly formatted hint
+      log_file_path: logFilePath,
+      tail_command: tailCommand, // Include the generated tail command
+      info_message: infoMessage, // Use the separate variable for settling details
+      exitCode: currentInfoAfterWait.exitCode ?? null,
+      signal: currentInfoAfterWait.signal ?? null,
+    };
+
+    log.info(
+    	label,
+    	`Returning result for start_process. Included ${successPayload.logs.length} log lines. Status: ${finalStatus}.`,
+    );
+
+    // If final status is error/crashed, return failure, otherwise success
+    if (["error", "crashed"].includes(finalStatus)) {
+      // ... (error payload construction remains the same) ...
+    }
+
+    return ok(textPayload(JSON.stringify(successPayload, null, 2))); // Ensure payload is stringified
+    ```
+
+**3. Update Zod Schema Descriptions (Optional but Recommended):**
+
+*   Open the file `src/types.ts`.
+*   Find the `StartSuccessPayloadSchema` definition.
+*   Update the `.describe()` calls for `monitoring_hint`, `info_message`, and potentially `tail_command` to reflect the new content and purpose:
+
+    ```typescript
+    // src/types.ts - Inside StartSuccessPayloadSchema definition
+
+    // ... other fields ...
+    monitoring_hint: z
+      .string()
+      .describe(
+        "Instructions for monitoring. If file logging is enabled, provides the 'tail' command phrased as an instruction ('If you requested to tail... run this command...'). Otherwise, directs to check_process_status.",
+      ),
+    log_file_path: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("Absolute path to the log file, if logging to file is enabled."),
+    tail_command: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "The specific command to run in a terminal to tail the log file, if available (e.g., 'tail -f /path/to/log'). Null if file logging is disabled.",
+      ),
+    info_message: z
+      .string()
+      .optional()
+      .describe(
+        "Optional secondary message providing technical details about startup (e.g., log settling status, timeouts).",
+      ),
+    // ... other fields ...
+    ```
+
+**4. Verification:**
+
+*   **Build:** Run `npm run build`.
+*   **Run:** Start the server with `node build/index.mjs`.
+*   **Test (File Logging Enabled):**
+    *   Use an MCP client (e.g., Inspector) to call `start_process` for a command where file logging *will* be enabled (ensure `serverLogDirectory` is created successfully by `main.ts`).
+    *   Examine the JSON response payload.
+    *   **Verify `monitoring_hint`:** It should look similar to: `"If you requested to tail the 'your-label' process, please run this command in a separate background terminal: tail -f \"/tmp/mcp-pm-logs-PID/your-label.log\". For status updates or recent inline logs, use check_process_status('your-label')."`
+    *   **Verify `tail_command`:** It should contain the actual `tail -f ...` command.
+    *   **Verify `info_message`:** It should contain the details about log settling/timeouts.
+    *   **Verify `message`:** It should be the concise "Process started..." message.
+*   **Test (File Logging Disabled):**
+    *   (If possible) Modify the server startup temporarily to prevent `serverLogDirectory` creation or simulate a failure, so `logFilePath` becomes null.
+    *   Call `start_process` again.
+    *   Examine the JSON response payload.
+    *   **Verify `monitoring_hint`:** It should look like: `"For status updates or recent inline logs, use check_process_status('your-label'). File logging is not enabled for this process."`
+    *   **Verify `tail_command`:** It should be `null`.
+
+---
+
+This refactoring changes the `monitoring_hint` to provide a direct instruction for tailing, framed conditionally ("If you requested..."), when file logging is available. It keeps the technical details about startup in `info_message` and the core status in `message`.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"watch": "tsc --watch",
 		"inspector": "npx @modelcontextprotocol/inspector build/index.mjs",
 		"lint:fix": "biome check --write .",
+		"verify": "npm run build && npm run lint:fix",
 		"start": "node build/index.mjs"
 	},
 	"dependencies": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,12 +186,26 @@ export const StartSuccessPayloadSchema = ProcessStatusInfoSchema.extend({
 	monitoring_hint: z
 		.string()
 		.describe(
-			"Guidance on how to monitor the process (e.g., using check_process_status or tail).",
+			"Instructions for monitoring. If file logging is enabled, provides the 'tail' command phrased as an instruction ('If you requested to tail... run this command...'). Otherwise, directs to check_process_status.",
+		),
+	log_file_path: z
+		.string()
+		.nullable()
+		.optional()
+		.describe("Absolute path to the log file, if logging to file is enabled."),
+	tail_command: z
+		.string()
+		.nullable()
+		.optional()
+		.describe(
+			"The specific command to run in a terminal to tail the log file, if available (e.g., 'tail -f /path/to/log'). Null if file logging is disabled.",
 		),
 	info_message: z
 		.string()
 		.optional()
-		.describe("Additional informational message (e.g., about log settling)."),
+		.describe(
+			"Optional secondary message providing technical details about startup (e.g., log settling status, timeouts).",
+		),
 }).describe("Response payload for a successful start_process call.");
 
 // Schema for start_process error payload (specific errors)


### PR DESCRIPTION
Refactors the monitoring_hint in the start_process success payload to provide a direct tail instruction when file logging is enabled. Updates related Zod schema descriptions.