### PR TITLE
feat: Add MCP PM Integration Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
 		"lint-staged": "^15.5.1",
 		"node-gyp": "^11.2.0",
 		"semantic-release": "^24.2.3",
-		"typescript": "^5.8.3"
+		"typescript": "^5.8.3",
+		"vitest": "^3.1.2"
 	},
 	"lint-staged": {
 		"*.{ts,tsx,js,jsx,json,md}": [

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
 		"lint:fix": "biome check --write .",
 		"verify": "npm run build && npm run lint:fix",
 		"start": "node build/index.mjs",
+		"test": "vitest run",
+		"test:watch": "vitest",
 		"postinstall": "pnpm rebuild node-pty"
 	},
 	"dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^3.1.2
+        version: 3.1.2(@types/node@22.15.3)(yaml@2.7.1)
 
 packages:
 
@@ -295,6 +298,9 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
   '@modelcontextprotocol/sdk@1.10.2':
     resolution: {integrity: sha512-rb6AMp2DR4SN+kc6L1ta2NCpApyA9WYNx3CrTSZvGxq9wH71bRur+zRqPfg0vQ9mjywR7qZdX2RGHOPq3ss+tA==}
     engines: {node: '>=18'}
@@ -383,6 +389,106 @@ packages:
     resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
     engines: {node: '>=12'}
 
+  '@rollup/rollup-android-arm-eabi@4.40.1':
+    resolution: {integrity: sha512-kxz0YeeCrRUHz3zyqvd7n+TVRlNyTifBsmnmNPtk3hQURUyG9eAB+usz6DAwagMusjx/zb3AjvDUvhFGDAexGw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.40.1':
+    resolution: {integrity: sha512-PPkxTOisoNC6TpnDKatjKkjRMsdaWIhyuMkA4UsBXT9WEZY4uHezBTjs6Vl4PbqQQeu6oION1w2voYZv9yquCw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.40.1':
+    resolution: {integrity: sha512-VWXGISWFY18v/0JyNUy4A46KCFCb9NVsH+1100XP31lud+TzlezBbz24CYzbnA4x6w4hx+NYCXDfnvDVO6lcAA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.40.1':
+    resolution: {integrity: sha512-nIwkXafAI1/QCS7pxSpv/ZtFW6TXcNUEHAIA9EIyw5OzxJZQ1YDrX+CL6JAIQgZ33CInl1R6mHet9Y/UZTg2Bw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.40.1':
+    resolution: {integrity: sha512-BdrLJ2mHTrIYdaS2I99mriyJfGGenSaP+UwGi1kB9BLOCu9SR8ZpbkmmalKIALnRw24kM7qCN0IOm6L0S44iWw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.40.1':
+    resolution: {integrity: sha512-VXeo/puqvCG8JBPNZXZf5Dqq7BzElNJzHRRw3vjBE27WujdzuOPecDPc/+1DcdcTptNBep3861jNq0mYkT8Z6Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.40.1':
+    resolution: {integrity: sha512-ehSKrewwsESPt1TgSE/na9nIhWCosfGSFqv7vwEtjyAqZcvbGIg4JAcV7ZEh2tfj/IlfBeZjgOXm35iOOjadcg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.40.1':
+    resolution: {integrity: sha512-m39iO/aaurh5FVIu/F4/Zsl8xppd76S4qoID8E+dSRQvTyZTOI2gVk3T4oqzfq1PtcvOfAVlwLMK3KRQMaR8lg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.40.1':
+    resolution: {integrity: sha512-Y+GHnGaku4aVLSgrT0uWe2o2Rq8te9hi+MwqGF9r9ORgXhmHK5Q71N757u0F8yU1OIwUIFy6YiJtKjtyktk5hg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.40.1':
+    resolution: {integrity: sha512-jEwjn3jCA+tQGswK3aEWcD09/7M5wGwc6+flhva7dsQNRZZTe30vkalgIzV4tjkopsTS9Jd7Y1Bsj6a4lzz8gQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.40.1':
+    resolution: {integrity: sha512-ySyWikVhNzv+BV/IDCsrraOAZ3UaC8SZB67FZlqVwXwnFhPihOso9rPOxzZbjp81suB1O2Topw+6Ug3JNegejQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.40.1':
+    resolution: {integrity: sha512-BvvA64QxZlh7WZWqDPPdt0GH4bznuL6uOO1pmgPnnv86rpUpc8ZxgZwcEgXvo02GRIZX1hQ0j0pAnhwkhwPqWg==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.40.1':
+    resolution: {integrity: sha512-EQSP+8+1VuSulm9RKSMKitTav89fKbHymTf25n5+Yr6gAPZxYWpj3DzAsQqoaHAk9YX2lwEyAf9S4W8F4l3VBQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.40.1':
+    resolution: {integrity: sha512-n/vQ4xRZXKuIpqukkMXZt9RWdl+2zgGNx7Uda8NtmLJ06NL8jiHxUawbwC+hdSq1rrw/9CghCpEONor+l1e2gA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.40.1':
+    resolution: {integrity: sha512-h8d28xzYb98fMQKUz0w2fMc1XuGzLLjdyxVIbhbil4ELfk5/orZlSTpF/xdI9C8K0I8lCkq+1En2RJsawZekkg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.40.1':
+    resolution: {integrity: sha512-XiK5z70PEFEFqcNj3/zRSz/qX4bp4QIraTy9QjwJAb/Z8GM7kVUsD0Uk8maIPeTyPCP03ChdI+VVmJriKYbRHQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.40.1':
+    resolution: {integrity: sha512-2BRORitq5rQ4Da9blVovzNCMaUlyKrzMSvkVR0D4qPuOy/+pMCrh1d7o01RATwVy+6Fa1WBw+da7QPeLWU/1mQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-win32-arm64-msvc@4.40.1':
+    resolution: {integrity: sha512-b2bcNm9Kbde03H+q+Jjw9tSfhYkzrDUf2d5MAd1bOJuVplXvFhWz7tRtWvD8/ORZi7qSCy0idW6tf2HgxSXQSg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.40.1':
+    resolution: {integrity: sha512-DfcogW8N7Zg7llVEfpqWMZcaErKfsj9VvmfSyRjCyo4BI3wPEfrzTtJkZG6gKP/Z92wFm6rz2aDO7/JfiR/whA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.40.1':
+    resolution: {integrity: sha512-ECyOuDeH3C1I8jH2MK1RtBJW+YPMvSfT0a5NN0nHfQYnDSJ6tUiZH3gzwVP5/Kfh/+Tt7tpWVF9LXNTnhTJ3kA==}
+    cpu: [x64]
+    os: [win32]
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -426,11 +532,43 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@types/estree@1.0.7':
+    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
   '@types/node@22.15.3':
     resolution: {integrity: sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@vitest/expect@3.1.2':
+    resolution: {integrity: sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==}
+
+  '@vitest/mocker@3.1.2':
+    resolution: {integrity: sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.1.2':
+    resolution: {integrity: sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==}
+
+  '@vitest/runner@3.1.2':
+    resolution: {integrity: sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==}
+
+  '@vitest/snapshot@3.1.2':
+    resolution: {integrity: sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==}
+
+  '@vitest/spy@3.1.2':
+    resolution: {integrity: sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==}
+
+  '@vitest/utils@3.1.2':
+    resolution: {integrity: sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==}
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -484,6 +622,10 @@ packages:
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -508,6 +650,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cacache@19.0.1:
     resolution: {integrity: sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -524,6 +670,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  chai@5.2.0:
+    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
+    engines: {node: '>=12'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -539,6 +689,10 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -673,6 +827,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -751,6 +909,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -774,6 +935,9 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -801,6 +965,10 @@ packages:
   execa@9.5.2:
     resolution: {integrity: sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.2.1:
+    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.2:
     resolution: {integrity: sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==}
@@ -887,6 +1055,11 @@ packages:
   fs-minipass@3.0.3:
     resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1205,8 +1378,14 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  loupe@3.1.3:
+    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
   make-fetch-happen@14.0.3:
     resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
@@ -1320,6 +1499,11 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -1560,6 +1744,13 @@ packages:
     resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
     engines: {node: '>=18'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1591,6 +1782,10 @@ packages:
   pkg-conf@2.1.0:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
+
+  postcss@8.5.3:
+    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+    engines: {node: ^10 || ^12 || >=14}
 
   pretty-ms@9.2.0:
     resolution: {integrity: sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==}
@@ -1683,6 +1878,11 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rollup@4.40.1:
+    resolution: {integrity: sha512-C5VvvgCCyfyotVITIAv+4efVytl5F7wt+/I2i9q9GZcEXW9BP52YYOXC58igUi+LFZVHukErIIqQSWwv/M3WRw==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -1752,6 +1952,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -1791,6 +1994,10 @@ packages:
     resolution: {integrity: sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -1820,9 +2027,15 @@ packages:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   stream-combiner2@1.1.1:
     resolution: {integrity: sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==}
@@ -1916,9 +2129,27 @@ packages:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.13:
     resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.0.2:
+    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2014,6 +2245,79 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite-node@3.1.2:
+    resolution: {integrity: sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@6.3.4:
+    resolution: {integrity: sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.1.2:
+    resolution: {integrity: sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.1.2
+      '@vitest/ui': 3.1.2
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2022,6 +2326,11 @@ packages:
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wordwrap@1.0.0:
@@ -2226,6 +2535,8 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
+  '@jridgewell/sourcemap-codec@1.5.0': {}
+
   '@modelcontextprotocol/sdk@1.10.2':
     dependencies:
       content-type: 1.0.5
@@ -2341,6 +2652,66 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
+  '@rollup/rollup-android-arm-eabi@4.40.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.40.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.40.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.40.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.40.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.40.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.40.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.40.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.40.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.40.1':
+    optional: true
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.40.1':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.40.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.40.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.40.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.40.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.40.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.40.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.40.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.40.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.40.1':
+    optional: true
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@semantic-release/commit-analyzer@13.0.1(semantic-release@24.2.3(typescript@5.8.3))':
@@ -2420,11 +2791,53 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@types/estree@1.0.7': {}
+
   '@types/node@22.15.3':
     dependencies:
       undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@vitest/expect@3.1.2':
+    dependencies:
+      '@vitest/spy': 3.1.2
+      '@vitest/utils': 3.1.2
+      chai: 5.2.0
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.1.2(vite@6.3.4(@types/node@22.15.3)(yaml@2.7.1))':
+    dependencies:
+      '@vitest/spy': 3.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.3.4(@types/node@22.15.3)(yaml@2.7.1)
+
+  '@vitest/pretty-format@3.1.2':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.1.2':
+    dependencies:
+      '@vitest/utils': 3.1.2
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.1.2':
+    dependencies:
+      '@vitest/pretty-format': 3.1.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.1.2':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@3.1.2':
+    dependencies:
+      '@vitest/pretty-format': 3.1.2
+      loupe: 3.1.3
+      tinyrainbow: 2.0.0
 
   abbrev@3.0.1: {}
 
@@ -2466,6 +2879,8 @@ snapshots:
 
   array-ify@1.0.0: {}
 
+  assertion-error@2.0.1: {}
+
   balanced-match@1.0.2: {}
 
   before-after-hook@3.0.2: {}
@@ -2496,6 +2911,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   cacache@19.0.1:
     dependencies:
       '@npmcli/fs': 4.0.0
@@ -2523,6 +2940,14 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  chai@5.2.0:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.3
+      pathval: 2.0.0
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -2537,6 +2962,8 @@ snapshots:
   chalk@5.4.1: {}
 
   char-regex@1.0.2: {}
+
+  check-error@2.1.1: {}
 
   chownr@3.0.0: {}
 
@@ -2669,6 +3096,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   deep-extend@0.6.0: {}
 
   default-shell@2.2.0: {}
@@ -2731,6 +3160,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -2770,6 +3201,10 @@ snapshots:
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@5.0.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.7
 
   etag@1.8.1: {}
 
@@ -2819,6 +3254,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.1
+
+  expect-type@1.2.1: {}
 
   exponential-backoff@3.1.2: {}
 
@@ -2942,6 +3379,9 @@ snapshots:
   fs-minipass@3.0.3:
     dependencies:
       minipass: 7.1.2
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -3252,7 +3692,13 @@ snapshots:
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
 
+  loupe@3.1.3: {}
+
   lru-cache@10.4.3: {}
+
+  magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   make-fetch-happen@14.0.3:
     dependencies:
@@ -3361,6 +3807,8 @@ snapshots:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
+
+  nanoid@3.3.11: {}
 
   negotiator@1.0.0: {}
 
@@ -3514,6 +3962,10 @@ snapshots:
 
   path-type@6.0.0: {}
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -3534,6 +3986,12 @@ snapshots:
     dependencies:
       find-up: 2.1.0
       load-json-file: 4.0.0
+
+  postcss@8.5.3:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   pretty-ms@9.2.0:
     dependencies:
@@ -3627,6 +4085,32 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rollup@4.40.1:
+    dependencies:
+      '@types/estree': 1.0.7
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.40.1
+      '@rollup/rollup-android-arm64': 4.40.1
+      '@rollup/rollup-darwin-arm64': 4.40.1
+      '@rollup/rollup-darwin-x64': 4.40.1
+      '@rollup/rollup-freebsd-arm64': 4.40.1
+      '@rollup/rollup-freebsd-x64': 4.40.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.40.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.40.1
+      '@rollup/rollup-linux-arm64-gnu': 4.40.1
+      '@rollup/rollup-linux-arm64-musl': 4.40.1
+      '@rollup/rollup-linux-loongarch64-gnu': 4.40.1
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.40.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.40.1
+      '@rollup/rollup-linux-riscv64-musl': 4.40.1
+      '@rollup/rollup-linux-s390x-gnu': 4.40.1
+      '@rollup/rollup-linux-x64-gnu': 4.40.1
+      '@rollup/rollup-linux-x64-musl': 4.40.1
+      '@rollup/rollup-win32-arm64-msvc': 4.40.1
+      '@rollup/rollup-win32-ia32-msvc': 4.40.1
+      '@rollup/rollup-win32-x64-msvc': 4.40.1
+      fsevents: 2.3.3
 
   router@2.2.0:
     dependencies:
@@ -3752,6 +4236,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -3793,6 +4279,8 @@ snapshots:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
 
+  source-map-js@1.2.1: {}
+
   source-map@0.6.1: {}
 
   spawn-error-forwarder@1.0.0: {}
@@ -3821,7 +4309,11 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
+  stackback@0.0.2: {}
+
   statuses@2.0.1: {}
+
+  std-env@3.9.0: {}
 
   stream-combiner2@1.1.1:
     dependencies:
@@ -3925,10 +4417,20 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.13:
     dependencies:
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
+
+  tinypool@1.0.2: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@3.0.2: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -3994,6 +4496,79 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite-node@3.1.2(@types/node@22.15.3)(yaml@2.7.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.3.4(@types/node@22.15.3)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@6.3.4(@types/node@22.15.3)(yaml@2.7.1):
+    dependencies:
+      esbuild: 0.25.3
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.3
+      rollup: 4.40.1
+      tinyglobby: 0.2.13
+    optionalDependencies:
+      '@types/node': 22.15.3
+      fsevents: 2.3.3
+      yaml: 2.7.1
+
+  vitest@3.1.2(@types/node@22.15.3)(yaml@2.7.1):
+    dependencies:
+      '@vitest/expect': 3.1.2
+      '@vitest/mocker': 3.1.2(vite@6.3.4(@types/node@22.15.3)(yaml@2.7.1))
+      '@vitest/pretty-format': 3.1.2
+      '@vitest/runner': 3.1.2
+      '@vitest/snapshot': 3.1.2
+      '@vitest/spy': 3.1.2
+      '@vitest/utils': 3.1.2
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.13
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.3.4(@types/node@22.15.3)(yaml@2.7.1)
+      vite-node: 3.1.2(@types/node@22.15.3)(yaml@2.7.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.15.3
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -4001,6 +4576,11 @@ snapshots:
   which@5.0.0:
     dependencies:
       isexe: 3.1.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wordwrap@1.0.0: {}
 

--- a/tests/integration/mcp-server.test.ts
+++ b/tests/integration/mcp-server.test.ts
@@ -24,6 +24,7 @@ describe("MCP Process Manager Server (Stdio Integration)", () => {
 	let serverWasKilled = false; // Flag to check if we killed it intentionally
 
 	beforeAll(async () => {
+		console.log("[TEST] BeforeAll: Setting up server...");
 		// Reset state for potentially retried tests
 		serverProcess = null;
 		serverErrorOutput = [];
@@ -38,7 +39,7 @@ describe("MCP Process Manager Server (Stdio Integration)", () => {
 		});
 
 		console.log(
-			`Spawning MCP server: ${SERVER_EXECUTABLE} ${SERVER_SCRIPT_PATH} ${SERVER_ARGS.join(" ")}`,
+			`[TEST] Spawning MCP server: ${SERVER_EXECUTABLE} ${SERVER_SCRIPT_PATH} ${SERVER_ARGS.join(" ")}`,
 		);
 		serverProcess = spawn(
 			SERVER_EXECUTABLE,
@@ -49,13 +50,14 @@ describe("MCP Process Manager Server (Stdio Integration)", () => {
 				// cwd: path.dirname(SERVER_SCRIPT_PATH), // Usually not needed if script path is absolute
 			},
 		);
+		console.log(`[TEST] Server process spawned with PID: ${serverProcess.pid}`);
 
 		let serverReady = false; // Flag to prevent double resolution
 
 		const startupTimeoutTimer = setTimeout(() => {
 			if (!serverReady) {
 				const err = new Error(
-					`Server startup timed out after ${STARTUP_TIMEOUT}ms. Stderr: ${serverErrorOutput.join("")}`,
+					`[TEST] Server startup timed out after ${STARTUP_TIMEOUT}ms. Stderr: ${serverErrorOutput.join("")}`,
 				);
 				console.error(err.message);
 				serverWasKilled = true;
@@ -66,6 +68,7 @@ describe("MCP Process Manager Server (Stdio Integration)", () => {
 
 		serverProcess.stdout.on("data", (data: Buffer) => {
 			const output = data.toString();
+			// console.log(`[Server STDOUT RAW]: ${output}`); // Log raw stdout data
 			serverStdoutOutput.push(output); // Store for debugging
 			// NOTE: MCP responses go to stdout, but the *ready* signal for mcp-pm goes to stderr
 			// console.log(`[Server STDOUT]: ${output.trim()}`);
@@ -73,12 +76,13 @@ describe("MCP Process Manager Server (Stdio Integration)", () => {
 
 		serverProcess.stderr.on("data", (data: Buffer) => {
 			const output = data.toString();
+			console.error(`[Server STDERR RAW]: ${output}`); // Log raw stderr data
 			serverErrorOutput.push(output); // Store for debugging/errors
 			console.error(`[Server STDERR]: ${output.trim()}`); // Log stderr for visibility
 
 			// Check for the ready signal in stderr
 			if (!serverReady && output.includes(SERVER_READY_OUTPUT)) {
-				console.log("MCP server ready signal detected.");
+				console.log("[TEST] MCP server ready signal detected in stderr.");
 				serverReady = true;
 				clearTimeout(startupTimeoutTimer);
 				resolveServerReady();
@@ -91,7 +95,7 @@ describe("MCP Process Manager Server (Stdio Integration)", () => {
 		});
 
 		serverProcess.on("error", (err) => {
-			console.error("Failed to start server process:", err);
+			console.error("[TEST] Failed to start server process:", err);
 			if (!serverReady) {
 				clearTimeout(startupTimeoutTimer);
 				rejectServerReady(err);
@@ -101,20 +105,18 @@ describe("MCP Process Manager Server (Stdio Integration)", () => {
 		serverProcess.on("exit", (code, signal) => {
 			serverExitCode = code;
 			console.log(
-				`Server process exited with code: ${code}, signal: ${signal}`,
+				`[TEST] Server process exited. Code: ${code}, Signal: ${signal}`,
 			);
 			if (!serverReady) {
 				clearTimeout(startupTimeoutTimer);
-				rejectServerReady(
-					new Error(
-						`Server process exited prematurely (code ${code}, signal ${signal}) before ready signal. Stderr: ${serverErrorOutput.join("")}`,
-					),
-				);
+				const errMsg = `Server process exited prematurely (code ${code}, signal ${signal}) before ready signal. Stderr: ${serverErrorOutput.join("")}`;
+				console.error(`[TEST] ${errMsg}`);
+				rejectServerReady(new Error(errMsg));
 			}
 			// If it exits *after* being ready but *before* we killed it, it might be an issue
 			else if (!serverWasKilled) {
 				console.warn(
-					`Server process exited unexpectedly after being ready (code ${code}, signal ${signal}).`,
+					`[TEST] Server process exited unexpectedly after being ready (code ${code}, signal ${signal}).`,
 				);
 				// We might want to fail ongoing tests if this happens, but that's complex.
 				// For now, just log it. The tests relying on the process will fail anyway.
@@ -122,16 +124,18 @@ describe("MCP Process Manager Server (Stdio Integration)", () => {
 		});
 
 		serverProcess.on("close", () => {
-			console.log("Server stdio streams closed.");
+			console.log("[TEST] Server stdio streams closed.");
 		});
 
 		try {
+			console.log("[TEST] Waiting for server ready promise...");
 			await serverReadyPromise;
-			console.log("Server startup successful.");
+			console.log("[TEST] Server startup successful.");
 		} catch (err) {
-			console.error("Server startup failed:", err);
+			console.error("[TEST] Server startup failed:", err);
 			// Ensure process is killed if startup failed partway
 			if (serverProcess && !serverProcess.killed) {
+				console.log("[TEST] Killing server process after startup failure...");
 				serverWasKilled = true;
 				serverProcess.kill("SIGKILL");
 			}
@@ -140,27 +144,37 @@ describe("MCP Process Manager Server (Stdio Integration)", () => {
 	}, TEST_TIMEOUT); // Vitest timeout for the hook
 
 	afterAll(async () => {
+		console.log("[TEST] AfterAll: Tearing down server...");
 		if (serverProcess && !serverProcess.killed) {
-			console.log("Terminating server process...");
+			console.log("[TEST] Terminating server process...");
 			serverWasKilled = true; // Signal that we initiated the kill
 			serverProcess.stdin.end(); // Close stdin first
 			const killed = serverProcess.kill("SIGTERM"); // Attempt graceful shutdown
 			if (killed) {
-				console.log("Sent SIGTERM to server process.");
+				console.log("[TEST] Sent SIGTERM to server process.");
 				// Wait briefly for graceful exit
 				await new Promise((resolve) => setTimeout(resolve, 500));
 				if (!serverProcess.killed) {
-					console.warn("Server did not exit after SIGTERM, sending SIGKILL.");
+					console.warn(
+						"[TEST] Server did not exit after SIGTERM, sending SIGKILL.",
+					);
 					serverProcess.kill("SIGKILL");
+				} else {
+					console.log(
+						"[TEST] Server process terminated gracefully after SIGTERM.",
+					);
 				}
 			} else {
-				console.warn("Failed to send SIGTERM, attempting SIGKILL directly.");
+				console.warn(
+					"[TEST] Failed to send SIGTERM, attempting SIGKILL directly.",
+				);
 				serverProcess.kill("SIGKILL");
 			}
 		} else {
-			console.log("Server process already terminated or not started.");
+			console.log("[TEST] Server process already terminated or not started.");
 		}
 		// Optional: Cleanup temporary directories/files if created by tests
+		console.log("[TEST] AfterAll: Teardown complete.");
 	});
 
 	// Can be placed inside the describe block or outside (if exported from a helper module)
@@ -175,6 +189,9 @@ describe("MCP Process Manager Server (Stdio Integration)", () => {
 			throw new Error('Request must have an "id" property');
 		}
 		const requestString = `${JSON.stringify(request)}\n`;
+		console.log(
+			`[sendRequest] Sending request (ID ${requestId}): ${requestString.trim()}`,
+		);
 
 		return new Promise((resolve, reject) => {
 			let responseBuffer = "";
@@ -184,40 +201,37 @@ describe("MCP Process Manager Server (Stdio Integration)", () => {
 			const timeoutTimer = setTimeout(() => {
 				if (!responseReceived) {
 					cleanup();
-					reject(
-						new Error(
-							`Timeout waiting for response ID ${requestId} after ${timeoutMs}ms. Request: ${JSON.stringify(request)}`,
-						),
-					);
+					const errorMsg = `Timeout waiting for response ID ${requestId} after ${timeoutMs}ms. Request: ${JSON.stringify(request)}`;
+					console.error(`[sendRequest] ${errorMsg}`);
+					reject(new Error(errorMsg));
 				}
 			}, timeoutMs);
 
 			const onData = (data: Buffer) => {
-				responseBuffer += data.toString();
-				// console.log(`[Raw STDOUT chunk]: ${data.toString()}`); // Debugging chunks
+				const rawChunk = data.toString();
+				// console.log(`[sendRequest] Received raw STDOUT chunk for ${requestId}: ${rawChunk}`); // Verbose: Log raw chunks
+				responseBuffer += rawChunk;
 				const lines = responseBuffer.split("\n");
 				responseBuffer = lines.pop() || ""; // Keep incomplete line fragment
 
 				for (const line of lines) {
 					if (line.trim() === "") continue;
-					// console.log(`[Processing line]: ${line}`); // Debugging lines
+					// console.log(`[sendRequest] Processing line for ${requestId}: ${line}`); // Verbose: Log processed lines
 					try {
 						const parsedResponse = JSON.parse(line);
 						if (parsedResponse.id === requestId) {
 							console.log(
-								`Received response for ID ${requestId}: ${line.trim()}`,
+								`[sendRequest] Received matching response for ID ${requestId}: ${line.trim()}`,
 							);
 							responseReceived = true;
 							cleanup();
 							resolve(parsedResponse);
 							return; // Found the response
 						}
+						// console.log(`[sendRequest] Ignoring response with different ID (${parsedResponse.id}) for request ${requestId}`); // Verbose: Log ignored responses
 					} catch (e) {
 						// Ignore lines that aren't valid JSON or don't match ID
-						console.warn(
-							`Failed to parse potential JSON line or non-matching ID: ${line}`,
-							e,
-						);
+						// console.warn(`[sendRequest] Failed to parse potential JSON line for ${requestId}: ${line}`, e); // Verbose: Log parse errors
 					}
 				}
 			};
@@ -225,26 +239,23 @@ describe("MCP Process Manager Server (Stdio Integration)", () => {
 			const onError = (err: Error) => {
 				if (!responseReceived) {
 					cleanup();
-					reject(
-						new Error(
-							`Server process emitted error while waiting for ID ${requestId}: ${err.message}`,
-						),
-					);
+					const errorMsg = `Server process emitted error while waiting for ID ${requestId}: ${err.message}`;
+					console.error(`[sendRequest] ${errorMsg}`);
+					reject(new Error(errorMsg));
 				}
 			};
 
 			const onExit = (code: number | null, signal: string | null) => {
 				if (!responseReceived) {
 					cleanup();
-					reject(
-						new Error(
-							`Server process exited (code ${code}, signal ${signal}) before response ID ${requestId} was received.`,
-						),
-					);
+					const errorMsg = `Server process exited (code ${code}, signal ${signal}) before response ID ${requestId} was received.`;
+					console.error(`[sendRequest] ${errorMsg}`);
+					reject(new Error(errorMsg));
 				}
 			};
 
 			const cleanup = () => {
+				// console.log(`[sendRequest] Cleaning up listeners for request ID ${requestId}`); // Verbose: Log listener cleanup
 				clearTimeout(timeoutTimer);
 				if (responseListenersAttached) {
 					process.stdout.removeListener("data", onData);
@@ -252,47 +263,126 @@ describe("MCP Process Manager Server (Stdio Integration)", () => {
 					process.removeListener("error", onError);
 					process.removeListener("exit", onExit);
 					responseListenersAttached = false; // Mark as removed
-					// console.log(`Listeners removed for request ID ${requestId}`);
 				}
 			};
 
 			// Temporary stderr listener during request wait (optional, for debugging)
 			const logStderr = (data: Buffer) => {
 				console.error(
-					`[Server STDERR during request ${requestId}]: ${data.toString().trim()}`,
+					`[sendRequest][Server STDERR during request ${requestId}]: ${data.toString().trim()}`,
 				);
 			};
 
 			// Attach listeners only once per request
 			if (!responseListenersAttached) {
+				// console.log(`[sendRequest] Attaching listeners for request ID ${requestId}`); // Verbose: Log listener attachment
 				process.stdout.on("data", onData);
 				process.stderr.on("data", logStderr); // Listen to stderr too
 				process.once("error", onError); // Use once for exit/error during wait
 				process.once("exit", onExit);
 				responseListenersAttached = true;
-				// console.log(`Listeners attached for request ID ${requestId}`);
 			}
 
 			// Write the request to stdin
-			console.log(`Sending request (ID ${requestId}): ${requestString.trim()}`);
+			// console.log(`[sendRequest] Writing request (ID ${requestId}) to stdin...`); // Verbose: Log stdin write
 			process.stdin.write(requestString, (err) => {
 				if (err) {
 					if (!responseReceived) {
 						// Check if already resolved/rejected
 						cleanup();
-						reject(
-							new Error(
-								`Failed to write to server stdin for ID ${requestId}: ${err.message}`,
-							),
-						);
+						const errorMsg = `Failed to write to server stdin for ID ${requestId}: ${err.message}`;
+						console.error(`[sendRequest] ${errorMsg}`);
+						reject(new Error(errorMsg));
 					}
+				} else {
+					// console.log(`[sendRequest] Successfully wrote request (ID ${requestId}) to stdin.`); // Verbose: Log successful stdin write
 				}
 			});
 		});
 	}
 
-	// Test cases will go here (Step 8 onwards)
-	it("placeholder test", () => {
-		expect(true).toBe(true);
-	});
+	it(
+		"should start a simple process and receive confirmation",
+		async () => {
+			console.log("[TEST][startProcess] Starting test...");
+			if (!serverProcess) {
+				throw new Error("Server process not initialized in beforeAll");
+			}
+			console.log("[TEST][startProcess] Server process check passed.");
+			const uniqueLabel = `test-process-${Date.now()}`;
+			const command = "node";
+			const args = [
+				"-e",
+				"console.log('Node process started'); setTimeout(() => console.log('Node process finished'), 200);",
+			];
+			const workingDirectory = path.resolve(__dirname); // Use test dir as CWD
+			console.log(
+				`[TEST][startProcess] Generated label: ${uniqueLabel}, CWD: ${workingDirectory}`,
+			);
+
+			const startRequest = {
+				jsonrpc: "2.0",
+				method: "start_process", // Final revert to underscore notation
+				params: {
+					command,
+					args,
+					workingDirectory,
+					label: uniqueLabel,
+				},
+				id: "req-start-1",
+			};
+			console.log("[TEST][startProcess] Sending start request...");
+
+			const response = (await sendRequest(
+				serverProcess,
+				startRequest,
+			)) as MCPResponse;
+			console.log(
+				"[TEST][startProcess] Received response:",
+				JSON.stringify(response),
+			);
+
+			console.log("[TEST][startProcess] Asserting response properties...");
+			expect(response.id).toBe("req-start-1");
+			expect(
+				response.result,
+				`Expected result to be defined, error: ${JSON.stringify(response.error)}`,
+			).toBeDefined();
+			expect(
+				response.error,
+				`Expected error to be undefined, got: ${JSON.stringify(response.error)}`,
+			).toBeUndefined();
+
+			console.log("[TEST][startProcess] Asserting result properties...");
+			const result = response.result as ProcessStatusResult; // Further cast for specific result
+			expect(result.label).toBe(uniqueLabel);
+			expect(result.status).toBe("running"); // Or 'starting' if verification is used
+			console.log("[TEST][startProcess] Assertions passed.");
+
+			// Optional: Add a short delay and check status again (tests checkProcessStatus)
+			console.log("[TEST][startProcess] Waiting briefly...");
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			// Cleanup: Stop the process (tests stopProcess)
+			const stopRequest = {
+				jsonrpc: "2.0",
+				method: "stop_process", // Final revert to underscore notation
+				params: { label: uniqueLabel },
+				id: "req-stop-cleanup-1",
+			};
+			console.log("[TEST][startProcess] Sending stop request for cleanup...");
+			// Check serverProcess again before sending stop request
+			if (!serverProcess) {
+				console.warn(
+					"[TEST][startProcess] Server process was unexpectedly null before sending stop request",
+				);
+				return; // Avoid error if process disappeared
+			}
+			await sendRequest(serverProcess, stopRequest);
+			console.log("[TEST][startProcess] Stop request sent.");
+			// We don't strictly need to await or check the stop response here, main goal is cleanup
+			console.log("[TEST][startProcess] Test finished.");
+		},
+		TEST_TIMEOUT,
+	); // Use longer timeout for test involving process lifetime
 });

--- a/tests/integration/mcp-server.test.ts
+++ b/tests/integration/mcp-server.test.ts
@@ -1,6 +1,7 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn } from "node:child_process";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 // --- Configuration ---
 const SERVER_EXECUTABLE = "node";
@@ -13,16 +14,130 @@ const STARTUP_TIMEOUT = 20000; // 20 seconds (adjust as needed)
 const TEST_TIMEOUT = STARTUP_TIMEOUT + 5000; // Test timeout slightly longer than startup
 
 describe("MCP Process Manager Server (Stdio Integration)", () => {
-	const serverProcess: ChildProcessWithoutNullStreams | null = null;
+	let serverProcess: ChildProcessWithoutNullStreams | null = null;
 	let serverReadyPromise: Promise<void>;
 	let resolveServerReady: () => void;
 	let rejectServerReady: (reason?: Error | string | undefined) => void;
-	const serverErrorOutput: string[] = []; // Store stderr output
-	const serverStdoutOutput: string[] = []; // Store stdout output (mostly for debugging)
-	const serverExitCode: number | null = null;
-	const serverWasKilled = false; // Flag to check if we killed it intentionally
+	let serverErrorOutput: string[] = []; // Store stderr output
+	let serverStdoutOutput: string[] = []; // Store stdout output (mostly for debugging)
+	let serverExitCode: number | null = null;
+	let serverWasKilled = false; // Flag to check if we killed it intentionally
 
-	// `beforeAll` and `afterAll` will go here (Step 5 & 6)
+	beforeAll(async () => {
+		// Reset state for potentially retried tests
+		serverProcess = null;
+		serverErrorOutput = [];
+		serverStdoutOutput = [];
+		serverExitCode = null;
+		serverWasKilled = false;
+
+		// Setup the promise *before* spawning
+		serverReadyPromise = new Promise((resolve, reject) => {
+			resolveServerReady = resolve;
+			rejectServerReady = reject;
+		});
+
+		console.log(
+			`Spawning MCP server: ${SERVER_EXECUTABLE} ${SERVER_SCRIPT_PATH} ${SERVER_ARGS.join(" ")}`,
+		);
+		serverProcess = spawn(
+			SERVER_EXECUTABLE,
+			[SERVER_SCRIPT_PATH, ...SERVER_ARGS],
+			{
+				stdio: ["pipe", "pipe", "pipe"], // pipe stdin, stdout, stderr
+				env: { ...process.env }, // Pass environment variables
+				// cwd: path.dirname(SERVER_SCRIPT_PATH), // Usually not needed if script path is absolute
+			},
+		);
+
+		let serverReady = false; // Flag to prevent double resolution
+
+		const startupTimeoutTimer = setTimeout(() => {
+			if (!serverReady) {
+				const err = new Error(
+					`Server startup timed out after ${STARTUP_TIMEOUT}ms. Stderr: ${serverErrorOutput.join("")}`,
+				);
+				console.error(err.message);
+				serverWasKilled = true;
+				serverProcess?.kill("SIGKILL"); // Force kill on timeout
+				rejectServerReady(err);
+			}
+		}, STARTUP_TIMEOUT);
+
+		serverProcess.stdout.on("data", (data: Buffer) => {
+			const output = data.toString();
+			serverStdoutOutput.push(output); // Store for debugging
+			// NOTE: MCP responses go to stdout, but the *ready* signal for mcp-pm goes to stderr
+			// console.log(`[Server STDOUT]: ${output.trim()}`);
+		});
+
+		serverProcess.stderr.on("data", (data: Buffer) => {
+			const output = data.toString();
+			serverErrorOutput.push(output); // Store for debugging/errors
+			console.error(`[Server STDERR]: ${output.trim()}`); // Log stderr for visibility
+
+			// Check for the ready signal in stderr
+			if (!serverReady && output.includes(SERVER_READY_OUTPUT)) {
+				console.log("MCP server ready signal detected.");
+				serverReady = true;
+				clearTimeout(startupTimeoutTimer);
+				resolveServerReady();
+			}
+			// Optional: Check for specific fatal startup errors here if known
+			// if (output.includes("FATAL ERROR")) {
+			//   clearTimeout(startupTimeoutTimer);
+			//   rejectServerReady(new Error(`Server emitted fatal error: ${output}`));
+			// }
+		});
+
+		serverProcess.on("error", (err) => {
+			console.error("Failed to start server process:", err);
+			if (!serverReady) {
+				clearTimeout(startupTimeoutTimer);
+				rejectServerReady(err);
+			}
+		});
+
+		serverProcess.on("exit", (code, signal) => {
+			serverExitCode = code;
+			console.log(
+				`Server process exited with code: ${code}, signal: ${signal}`,
+			);
+			if (!serverReady) {
+				clearTimeout(startupTimeoutTimer);
+				rejectServerReady(
+					new Error(
+						`Server process exited prematurely (code ${code}, signal ${signal}) before ready signal. Stderr: ${serverErrorOutput.join("")}`,
+					),
+				);
+			}
+			// If it exits *after* being ready but *before* we killed it, it might be an issue
+			else if (!serverWasKilled) {
+				console.warn(
+					`Server process exited unexpectedly after being ready (code ${code}, signal ${signal}).`,
+				);
+				// We might want to fail ongoing tests if this happens, but that's complex.
+				// For now, just log it. The tests relying on the process will fail anyway.
+			}
+		});
+
+		serverProcess.on("close", () => {
+			console.log("Server stdio streams closed.");
+		});
+
+		try {
+			await serverReadyPromise;
+			console.log("Server startup successful.");
+		} catch (err) {
+			console.error("Server startup failed:", err);
+			// Ensure process is killed if startup failed partway
+			if (serverProcess && !serverProcess.killed) {
+				serverWasKilled = true;
+				serverProcess.kill("SIGKILL");
+			}
+			throw err; // Re-throw to fail the test setup
+		}
+	}, TEST_TIMEOUT); // Vitest timeout for the hook
 
 	// Test cases will go here (Step 8 onwards)
 	it("placeholder test", () => {

--- a/tests/integration/mcp-server.test.ts
+++ b/tests/integration/mcp-server.test.ts
@@ -1,0 +1,31 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// --- Configuration ---
+const SERVER_EXECUTABLE = "node";
+// Resolve path from 'tests/integration/' to 'build/index.mjs'
+const SERVER_SCRIPT_PATH = path.resolve(__dirname, "../../build/index.mjs");
+const SERVER_ARGS: string[] = []; // No specific args needed to start
+// From src/main.ts log output
+const SERVER_READY_OUTPUT = "MCP Server connected and listening via stdio.";
+const STARTUP_TIMEOUT = 20000; // 20 seconds (adjust as needed)
+const TEST_TIMEOUT = STARTUP_TIMEOUT + 5000; // Test timeout slightly longer than startup
+
+describe("MCP Process Manager Server (Stdio Integration)", () => {
+	const serverProcess: ChildProcessWithoutNullStreams | null = null;
+	let serverReadyPromise: Promise<void>;
+	let resolveServerReady: () => void;
+	let rejectServerReady: (reason?: Error | string | undefined) => void;
+	const serverErrorOutput: string[] = []; // Store stderr output
+	const serverStdoutOutput: string[] = []; // Store stdout output (mostly for debugging)
+	const serverExitCode: number | null = null;
+	const serverWasKilled = false; // Flag to check if we killed it intentionally
+
+	// `beforeAll` and `afterAll` will go here (Step 5 & 6)
+
+	// Test cases will go here (Step 8 onwards)
+	it("placeholder test", () => {
+		expect(true).toBe(true);
+	});
+});


### PR DESCRIPTION
Adds a comprehensive integration test suite for the MCP Process Manager tool using Vitest. Covers start, stop, list, check, restart operations via stdio communication. Includes fixes for restart race condition and method call format.