### PR TITLE
ci: disable git checks during pnpm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       # Publish to NPM using pnpm, only if a new release was created
       - name: Publish to NPM
         if: steps.semantic.outputs.new_release_published == 'true' # Check output
-        run: pnpm publish --access public
+        run: pnpm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # Use NODE_AUTH_TOKEN for pnpm auth
 


### PR DESCRIPTION
This commit was missed in the previous merged PR (#22). It adds the --no-git-checks flag to the pnpm publish command in the release workflow to prevent failures due to unclean git status after the build step.