### PR TITLE
fix: include prompts in log analysis summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"verify": "pnpm build && pnpm lint:fix",
 		"start": "node build/index.mjs",
 		"test": "pnpm verify && vitest run --test-timeout=60000",
+		"test:single": "pnpm verify && vitest run --test-timeout=60000",
 		"test:verbose": "pnpm verify && MCP_TEST_VERBOSE=1 vitest run --test-timeout=60000",
 		"test:watch": "pnpm verify && vitest",
 		"test:filter-logs": "pnpm verify && vitest run -t \"should filter logs correctly on repeated checks of an active process\"",

--- a/src/logAnalysis.ts
+++ b/src/logAnalysis.ts
@@ -11,7 +11,7 @@ export function analyseLogs(logs: string[]): ChangeSummary {
 	const warnings = logs.filter((l) => /\bwarn(ing)?\b/i.test(l));
 	const urls = logs.filter((l) => /(https?:\/\/[^\s]+)/i.test(l));
 	const prompts = logs.filter((l) =>
-		/(?:\?|\binput\b|\bpassword\b).*[:?]$/i.test(l),
+		/(?:\?|\binput\b|\bpassword\b).*[:?]\s*$/i.test(l),
 	);
 
 	const notable = [...errors, ...warnings, ...urls, ...prompts];


### PR DESCRIPTION
## Summary of Changes

This PR fixes a failing unit test related to log analysis.

### Problem

The test `summarises a mixed bag of logs` in `tests/unit/logAnalysis.test.ts` was failing. The `analyseLogs` function was not correctly identifying log lines indicating user prompts (e.g., "Enter admin password: ") and therefore wasn't including the "Prompts (1)" count in the generated summary message.

### Solution

1.  **Updated Prompt Regex:** Modified the regular expression in `src/logAnalysis.ts` used to detect prompts. The regex now allows for optional trailing whitespace after the final colon or question mark (`[:?]\s*$`), making it correctly match lines like `"Enter admin password: "`.
2.  **Updated `test:single` Script:** Modified the `test:single` script in `package.json` to remove the default `-t` flag. This allows passing test name filters directly via the command line (e.g., `pnpm test:single -t "my test name"`), which was necessary for targeted testing during debugging.

### Verification

The fix was verified by running the specific failing test (`pnpm test:single -t "summarises a mixed bag of logs"`), which now passes. All tests passed in the pre-push hook as well. 